### PR TITLE
feat(iam): support accessPolicy parameter for readonly bucket access

### DIFF
--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -185,6 +185,12 @@ func (s *provisionerServer) DriverGrantBucketAccess(ctx context.Context, req *co
 		return nil, status.Error(codes.InvalidArgument, "user or bucket empty")
 	}
 
+	// determine IAM actions based on accessPolicy parameter
+	actions, err := actionsForPolicy(req.GetParameters()["accessPolicy"])
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	accessKey, _ := GenerateAccessKeyID()
 	secretKey, _ := GenerateSecretAccessKey()
 
@@ -213,7 +219,7 @@ func (s *provisionerServer) DriverGrantBucketAccess(ctx context.Context, req *co
 		cfg.Identities = append(cfg.Identities, id)
 	}
 	id.Credentials = append(id.Credentials, &iam_pb.Credential{AccessKey: accessKey, SecretKey: secretKey})
-	for _, a := range []string{"Read", "Write", "List", "Tagging"} {
+	for _, a := range actions {
 		action := fmt.Sprintf("%s:%s", a, bucket)
 		if !contains(id.Actions, action) {
 			id.Actions = append(id.Actions, action)
@@ -410,6 +416,19 @@ func validateObjectLockParams(params map[string]string) error {
 	}
 
 	return nil
+}
+
+// actionsForPolicy returns the IAM action names for the given access policy.
+// Supported values: "readonly", "readwrite", "" (defaults to readwrite).
+func actionsForPolicy(policy string) ([]string, error) {
+	switch policy {
+	case "readonly":
+		return []string{"Read", "List"}, nil
+	case "readwrite", "":
+		return []string{"Read", "Write", "List", "Tagging"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported accessPolicy %q, must be \"readonly\" or \"readwrite\"", policy)
+	}
 }
 
 func contains(ss []string, s string) bool {

--- a/pkg/driver/provisioner_test.go
+++ b/pkg/driver/provisioner_test.go
@@ -24,10 +24,12 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -121,6 +123,79 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 			if resp.Credentials["s3"].Secrets["accessKeyID"] == "" ||
 				resp.Credentials["s3"].Secrets["accessSecretKey"] == "" {
 				t.Errorf("credentials missing")
+			}
+		})
+	}
+}
+
+// iamActions parses the fakeFiler IAM buffer and returns sorted actions for the given identity.
+func iamActions(t *testing.T, ff *fakeFiler, identity string) []string {
+	t.Helper()
+	cfg := &iam_pb.S3ApiConfiguration{}
+	if ff.iam.Len() > 0 {
+		if err := filer.ParseS3ConfigurationFromBytes(ff.iam.Bytes(), cfg); err != nil {
+			t.Fatalf("parse IAM config: %v", err)
+		}
+	}
+	for _, id := range cfg.Identities {
+		if id.Name == identity {
+			actions := make([]string, len(id.Actions))
+			copy(actions, id.Actions)
+			sort.Strings(actions)
+			return actions
+		}
+	}
+	t.Fatalf("identity %q not found in IAM config", identity)
+	return nil
+}
+
+func TestDriverGrantBucketAccessPolicy(t *testing.T) {
+	cases := []struct {
+		name        string
+		params      map[string]string
+		wantActions []string
+		wantErr     bool
+	}{
+		{
+			name:        "readonly access",
+			params:      map[string]string{"accessPolicy": "readonly"},
+			wantActions: []string{"List:b", "Read:b"},
+		},
+		{
+			name:        "readwrite access",
+			params:      map[string]string{"accessPolicy": "readwrite"},
+			wantActions: []string{"List:b", "Read:b", "Tagging:b", "Write:b"},
+		},
+		{
+			name:        "default access (no param)",
+			params:      nil,
+			wantActions: []string{"List:b", "Read:b", "Tagging:b", "Write:b"},
+		},
+		{
+			name:    "invalid access policy",
+			params:  map[string]string{"accessPolicy": "invalid"},
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, ff := newProv(t)
+			req := &cosispec.DriverGrantBucketAccessRequest{
+				BucketId:   "b",
+				Name:       "u",
+				Parameters: c.params,
+			}
+			_, err := p.DriverGrantBucketAccess(context.Background(), req)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, c.wantErr)
+			}
+			if c.wantErr {
+				return
+			}
+			got := iamActions(t, ff, "u")
+			if !reflect.DeepEqual(got, c.wantActions) {
+				t.Errorf("actions=%v want %v", got, c.wantActions)
 			}
 		})
 	}


### PR DESCRIPTION
## What this PR does

Adds support for the `accessPolicy` key in `BucketAccessClass.parameters`,
allowing COSI consumers to request read-only bucket access.

- `"readonly"` grants `Read` and `List` actions only
- `"readwrite"` (or empty/missing — the default) grants `Read`, `Write`, `List`, `Tagging` (preserving existing behavior)
- Any other value returns an `InvalidArgument` error

Ref: kubernetes-sigs/container-object-storage-interface#244

## Test plan

- [x] Unit tests for readonly, readwrite, default, and invalid access policies
- [x] All existing tests pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access policies now determine the exact permissions granted per bucket (policy-based actions).

* **Bug Fixes**
  * Unsupported or invalid accessPolicy values are now detected and rejected with a clear error.

* **Improvements**
  * Dynamic, per-bucket permission calculation replaces the previous fixed-permissions approach for more accurate access control.

* **Tests**
  * Added tests validating policy-to-permission mappings and error handling for invalid policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->