### PR TITLE
feat(bucket): support Object Lock (WORM) via BucketClass parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,6 +111,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/schema v1.4.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -356,7 +356,16 @@ func (s *provisionerServer) configureS3Access(ctx context.Context, user, ak, sk 
 
 // validateObjectLockParams checks BucketClass parameters related to Object Lock.
 func validateObjectLockParams(params map[string]string) error {
-	enabled := params["objectLockEnabled"] == "true"
+	rawEnabled := params["objectLockEnabled"]
+	var enabled bool
+	switch rawEnabled {
+	case "true":
+		enabled = true
+	case "false", "":
+		enabled = false
+	default:
+		return fmt.Errorf("objectLockEnabled must be \"true\" or \"false\", got %q", rawEnabled)
+	}
 
 	mode := params["objectLockRetentionMode"]
 	days := params["objectLockRetentionDays"]

--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -24,12 +24,14 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -98,19 +100,38 @@ func (s *provisionerServer) withFilerClient(ctx context.Context, fn func(filer_p
 /*                           bucket primitives                                */
 /* -------------------------------------------------------------------------- */
 
-func (s *provisionerServer) createBucket(ctx context.Context, name string) error {
+func (s *provisionerServer) createBucket(ctx context.Context, name string, params map[string]string) error {
 	return s.withFilerClient(ctx, func(c filer_pb.SeaweedFilerClient) error {
+		now := time.Now().Unix()
+		entry := &filer_pb.Entry{
+			Name:        name,
+			IsDirectory: true,
+			Attributes: &filer_pb.FuseAttributes{
+				FileMode: uint32(0777 | os.ModeDir),
+				Crtime:   now,
+				Mtime:    now,
+			},
+		}
+
+		if params["objectLockEnabled"] == "true" {
+			entry.Extended = map[string][]byte{
+				s3_constants.ExtVersioningKey:        []byte(s3_constants.VersioningEnabled),
+				s3_constants.ExtObjectLockEnabledKey: []byte(s3_constants.ObjectLockEnabled),
+			}
+			if mode := params["objectLockRetentionMode"]; mode != "" {
+				entry.Extended[s3_constants.ExtObjectLockDefaultModeKey] = []byte(mode)
+				if days := params["objectLockRetentionDays"]; days != "" {
+					entry.Extended[s3_constants.ExtObjectLockDefaultDaysKey] = []byte(days)
+				}
+				if years := params["objectLockRetentionYears"]; years != "" {
+					entry.Extended[s3_constants.ExtObjectLockDefaultYearsKey] = []byte(years)
+				}
+			}
+		}
+
 		_, err := c.CreateEntry(ctx, &filer_pb.CreateEntryRequest{
 			Directory: s.filerBucketsPath,
-			Entry: &filer_pb.Entry{
-				Name:        name,
-				IsDirectory: true,
-				Attributes: &filer_pb.FuseAttributes{
-					FileMode: uint32(0777 | os.ModeDir),
-					Crtime:   time.Now().Unix(),
-					Mtime:    time.Now().Unix(),
-				},
-			},
+			Entry:     entry,
 		})
 		return err
 	})
@@ -135,7 +156,11 @@ func (s *provisionerServer) deleteBucket(ctx context.Context, id string) error {
 
 func (s *provisionerServer) DriverCreateBucket(ctx context.Context, req *cosispec.DriverCreateBucketRequest) (*cosispec.DriverCreateBucketResponse, error) {
 	klog.InfoS("creating bucket", "name", req.GetName())
-	if err := s.createBucket(ctx, req.GetName()); err != nil {
+	params := req.GetParameters()
+	if err := validateObjectLockParams(params); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	if err := s.createBucket(ctx, req.GetName(), params); err != nil {
 		klog.ErrorS(err, "create bucket failed")
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -328,6 +353,50 @@ func (s *provisionerServer) configureS3Access(ctx context.Context, user, ak, sk 
 /* -------------------------------------------------------------------------- */
 /*                               utilities                                    */
 /* -------------------------------------------------------------------------- */
+
+// validateObjectLockParams checks BucketClass parameters related to Object Lock.
+func validateObjectLockParams(params map[string]string) error {
+	if params["objectLockEnabled"] != "true" {
+		return nil
+	}
+
+	mode := params["objectLockRetentionMode"]
+	days := params["objectLockRetentionDays"]
+	years := params["objectLockRetentionYears"]
+
+	if mode != "" && mode != "GOVERNANCE" && mode != "COMPLIANCE" {
+		return fmt.Errorf("objectLockRetentionMode must be GOVERNANCE or COMPLIANCE, got %q", mode)
+	}
+
+	if days != "" && years != "" {
+		return fmt.Errorf("objectLockRetentionDays and objectLockRetentionYears are mutually exclusive")
+	}
+
+	if days != "" {
+		n, err := strconv.Atoi(days)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("objectLockRetentionDays must be a positive integer, got %q", days)
+		}
+	}
+
+	if years != "" {
+		n, err := strconv.Atoi(years)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("objectLockRetentionYears must be a positive integer, got %q", years)
+		}
+	}
+
+	hasMode := mode != ""
+	hasPeriod := days != "" || years != ""
+	if hasMode != hasPeriod {
+		if hasMode {
+			return fmt.Errorf("objectLockRetentionMode requires objectLockRetentionDays or objectLockRetentionYears")
+		}
+		return fmt.Errorf("objectLockRetentionDays/Years requires objectLockRetentionMode")
+	}
+
+	return nil
+}
 
 func contains(ss []string, s string) bool {
 	for _, v := range ss {

--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -356,13 +356,18 @@ func (s *provisionerServer) configureS3Access(ctx context.Context, user, ak, sk 
 
 // validateObjectLockParams checks BucketClass parameters related to Object Lock.
 func validateObjectLockParams(params map[string]string) error {
-	if params["objectLockEnabled"] != "true" {
-		return nil
-	}
+	enabled := params["objectLockEnabled"] == "true"
 
 	mode := params["objectLockRetentionMode"]
 	days := params["objectLockRetentionDays"]
 	years := params["objectLockRetentionYears"]
+
+	if !enabled {
+		if mode != "" || days != "" || years != "" {
+			return fmt.Errorf("objectLockEnabled must be true when retention parameters are set")
+		}
+		return nil
+	}
 
 	if mode != "" && mode != "GOVERNANCE" && mode != "COMPLIANCE" {
 		return fmt.Errorf("objectLockRetentionMode must be GOVERNANCE or COMPLIANCE, got %q", mode)
@@ -375,14 +380,14 @@ func validateObjectLockParams(params map[string]string) error {
 	if days != "" {
 		n, err := strconv.Atoi(days)
 		if err != nil || n <= 0 {
-			return fmt.Errorf("objectLockRetentionDays must be a positive integer, got %q", days)
+			return fmt.Errorf("objectLockRetentionDays must be a positive integer (greater than 0), got %q", days)
 		}
 	}
 
 	if years != "" {
 		n, err := strconv.Atoi(years)
 		if err != nil || n <= 0 {
-			return fmt.Errorf("objectLockRetentionYears must be a positive integer, got %q", years)
+			return fmt.Errorf("objectLockRetentionYears must be a positive integer (greater than 0), got %q", years)
 		}
 	}
 

--- a/pkg/driver/provisioner_test.go
+++ b/pkg/driver/provisioner_test.go
@@ -280,6 +280,37 @@ func TestDriverCreateBucketObjectLock(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:    "invalid objectLockEnabled value",
+			params:  map[string]string{"objectLockEnabled": "True"},
+			wantErr: true,
+		},
+		{
+			name: "years is zero",
+			params: map[string]string{
+				"objectLockEnabled":        "true",
+				"objectLockRetentionMode":  "COMPLIANCE",
+				"objectLockRetentionYears": "0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "years is not a number",
+			params: map[string]string{
+				"objectLockEnabled":        "true",
+				"objectLockRetentionMode":  "COMPLIANCE",
+				"objectLockRetentionYears": "abc",
+			},
+			wantErr: true,
+		},
+		{
+			name: "years without mode",
+			params: map[string]string{
+				"objectLockEnabled":        "true",
+				"objectLockRetentionYears": "2",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/driver/provisioner_test.go
+++ b/pkg/driver/provisioner_test.go
@@ -272,6 +272,14 @@ func TestDriverCreateBucketObjectLock(t *testing.T) {
 			params:     map[string]string{"objectLockEnabled": "false"},
 			wantExtKey: nil,
 		},
+		{
+			name: "retention params without objectLockEnabled",
+			params: map[string]string{
+				"objectLockRetentionMode": "COMPLIANCE",
+				"objectLockRetentionDays": "30",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/driver/provisioner_test.go
+++ b/pkg/driver/provisioner_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	cosispec "sigs.k8s.io/container-object-storage-interface-spec"
@@ -37,13 +38,20 @@ import (
 
 type fakeFiler struct {
 	filer_pb.UnimplementedSeaweedFilerServer
-	iam bytes.Buffer
+	iam     bytes.Buffer
+	buckets map[string]*filer_pb.Entry
 }
 
 func (f *fakeFiler) CreateEntry(ctx context.Context, in *filer_pb.CreateEntryRequest) (*filer_pb.CreateEntryResponse, error) {
 	if in.Directory == filer.IamConfigDirectory {
 		f.iam.Reset()
 		f.iam.Write(in.Entry.Content)
+	}
+	if in.Directory == "/buckets" {
+		if f.buckets == nil {
+			f.buckets = make(map[string]*filer_pb.Entry)
+		}
+		f.buckets[in.Entry.Name] = in.Entry
 	}
 	return &filer_pb.CreateEntryResponse{}, nil
 }
@@ -64,28 +72,29 @@ func (*fakeFiler) DeleteEntry(context.Context, *filer_pb.DeleteEntryRequest) (*f
 
 /* ------------------------- helper: real TCP gRPC server ----------------------- */
 
-func newProv(t *testing.T) *provisionerServer {
+func newProv(t *testing.T) (*provisionerServer, *fakeFiler) {
 	t.Helper()
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
+	ff := &fakeFiler{}
 	srv := grpc.NewServer()
-	filer_pb.RegisterSeaweedFilerServer(srv, &fakeFiler{})
+	filer_pb.RegisterSeaweedFilerServer(srv, ff)
 	go srv.Serve(lis)
 
 	p, err := NewProvisionerServer("prov", lis.Addr().String(), "", "", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("init prov: %v", err)
 	}
-	return p.(*provisionerServer)
+	return p.(*provisionerServer), ff
 }
 
 /* ----------------------------------- tests ----------------------------------- */
 
 func TestDriverGrantBucketAccess(t *testing.T) {
-	p := newProv(t)
+	p, _ := newProv(t)
 
 	cases := []struct {
 		name    string
@@ -118,7 +127,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 }
 
 func TestDriverRevokeBucketAccess(t *testing.T) {
-	p := newProv(t)
+	p, _ := newProv(t)
 	_, _ = p.DriverGrantBucketAccess(context.Background(),
 		&cosispec.DriverGrantBucketAccessRequest{BucketId: "b", Name: "u"})
 
@@ -139,6 +148,189 @@ func TestDriverRevokeBucketAccess(t *testing.T) {
 			}
 			if !c.wantErr && !reflect.DeepEqual(got, &cosispec.DriverRevokeBucketAccessResponse{}) {
 				t.Errorf("unexpected resp=%+v", got)
+			}
+		})
+	}
+}
+
+// bucketExtended returns the Extended map from a stored bucket entry.
+func bucketExtended(t *testing.T, ff *fakeFiler, name string) map[string][]byte {
+	t.Helper()
+	if ff.buckets == nil {
+		return nil
+	}
+	e, ok := ff.buckets[name]
+	if !ok {
+		t.Fatalf("bucket %q not found in fakeFiler", name)
+	}
+	return e.Extended
+}
+
+func TestDriverCreateBucketObjectLock(t *testing.T) {
+	cases := []struct {
+		name       string
+		params     map[string]string
+		wantErr    bool
+		wantExtKey []string // expected Extended keys
+	}{
+		{
+			name:       "plain bucket (no params)",
+			params:     nil,
+			wantExtKey: nil,
+		},
+		{
+			name:   "object lock enabled",
+			params: map[string]string{"objectLockEnabled": "true"},
+			wantExtKey: []string{
+				s3_constants.ExtVersioningKey,
+				s3_constants.ExtObjectLockEnabledKey,
+			},
+		},
+		{
+			name: "object lock with COMPLIANCE retention 30 days",
+			params: map[string]string{
+				"objectLockEnabled":       "true",
+				"objectLockRetentionMode": "COMPLIANCE",
+				"objectLockRetentionDays": "30",
+			},
+			wantExtKey: []string{
+				s3_constants.ExtVersioningKey,
+				s3_constants.ExtObjectLockEnabledKey,
+				s3_constants.ExtObjectLockDefaultModeKey,
+				s3_constants.ExtObjectLockDefaultDaysKey,
+			},
+		},
+		{
+			name: "object lock with GOVERNANCE retention 2 years",
+			params: map[string]string{
+				"objectLockEnabled":        "true",
+				"objectLockRetentionMode":  "GOVERNANCE",
+				"objectLockRetentionYears": "2",
+			},
+			wantExtKey: []string{
+				s3_constants.ExtVersioningKey,
+				s3_constants.ExtObjectLockEnabledKey,
+				s3_constants.ExtObjectLockDefaultModeKey,
+				s3_constants.ExtObjectLockDefaultYearsKey,
+			},
+		},
+		{
+			name: "invalid retention mode",
+			params: map[string]string{
+				"objectLockEnabled":       "true",
+				"objectLockRetentionMode": "INVALID",
+				"objectLockRetentionDays": "10",
+			},
+			wantErr: true,
+		},
+		{
+			name: "days and years both set",
+			params: map[string]string{
+				"objectLockEnabled":        "true",
+				"objectLockRetentionMode":  "COMPLIANCE",
+				"objectLockRetentionDays":  "30",
+				"objectLockRetentionYears": "1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "mode without period",
+			params: map[string]string{
+				"objectLockEnabled":       "true",
+				"objectLockRetentionMode": "GOVERNANCE",
+			},
+			wantErr: true,
+		},
+		{
+			name: "days without mode",
+			params: map[string]string{
+				"objectLockEnabled":       "true",
+				"objectLockRetentionDays": "30",
+			},
+			wantErr: true,
+		},
+		{
+			name: "days is zero",
+			params: map[string]string{
+				"objectLockEnabled":       "true",
+				"objectLockRetentionMode": "COMPLIANCE",
+				"objectLockRetentionDays": "0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "days is not a number",
+			params: map[string]string{
+				"objectLockEnabled":       "true",
+				"objectLockRetentionMode": "COMPLIANCE",
+				"objectLockRetentionDays": "abc",
+			},
+			wantErr: true,
+		},
+		{
+			name:       "objectLockEnabled=false treated as plain bucket",
+			params:     map[string]string{"objectLockEnabled": "false"},
+			wantExtKey: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, ff := newProv(t)
+			req := &cosispec.DriverCreateBucketRequest{
+				Name:       "test-bucket",
+				Parameters: c.params,
+			}
+			_, err := p.DriverCreateBucket(context.Background(), req)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, c.wantErr)
+			}
+			if c.wantErr {
+				return
+			}
+
+			ext := bucketExtended(t, ff, "test-bucket")
+			if len(c.wantExtKey) == 0 {
+				if len(ext) != 0 {
+					t.Errorf("expected no Extended, got %v", ext)
+				}
+				return
+			}
+
+			for _, k := range c.wantExtKey {
+				if _, ok := ext[k]; !ok {
+					t.Errorf("missing Extended key %q", k)
+				}
+			}
+			if len(ext) != len(c.wantExtKey) {
+				t.Errorf("Extended has %d keys, want %d", len(ext), len(c.wantExtKey))
+			}
+
+			// verify specific values for object lock keys
+			if v, ok := ext[s3_constants.ExtVersioningKey]; ok {
+				if string(v) != s3_constants.VersioningEnabled {
+					t.Errorf("versioning=%q want %q", v, s3_constants.VersioningEnabled)
+				}
+			}
+			if v, ok := ext[s3_constants.ExtObjectLockEnabledKey]; ok {
+				if string(v) != s3_constants.ObjectLockEnabled {
+					t.Errorf("objectLockEnabled=%q want %q", v, s3_constants.ObjectLockEnabled)
+				}
+			}
+			if mode := c.params["objectLockRetentionMode"]; mode != "" {
+				if string(ext[s3_constants.ExtObjectLockDefaultModeKey]) != mode {
+					t.Errorf("mode=%q want %q", ext[s3_constants.ExtObjectLockDefaultModeKey], mode)
+				}
+			}
+			if days := c.params["objectLockRetentionDays"]; days != "" {
+				if string(ext[s3_constants.ExtObjectLockDefaultDaysKey]) != days {
+					t.Errorf("days=%q want %q", ext[s3_constants.ExtObjectLockDefaultDaysKey], days)
+				}
+			}
+			if years := c.params["objectLockRetentionYears"]; years != "" {
+				if string(ext[s3_constants.ExtObjectLockDefaultYearsKey]) != years {
+					t.Errorf("years=%q want %q", ext[s3_constants.ExtObjectLockDefaultYearsKey], years)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add Object Lock / WORM support to bucket creation via BucketClass parameters
- When `objectLockEnabled=true`, versioning and Object Lock extended attributes are set on the filer bucket entry
- Optional default retention (GOVERNANCE/COMPLIANCE with days or years) is propagated to SeaweedFS extended attributes
- Full parameter validation: mode values, mutual exclusivity of days/years, mode+period consistency, positive integers

## BucketClass parameters

| Parameter | Values | Description |
| --- | --- | --- |
| `objectLockEnabled` | `"true"` | Enables Object Lock + versioning |
| `objectLockRetentionMode` | `"GOVERNANCE"` / `"COMPLIANCE"` | Default retention mode |
| `objectLockRetentionDays` | positive integer | Default retention in days |
| `objectLockRetentionYears` | positive integer | Default retention in years |

## Test plan

- [x] 11 test cases covering all Object Lock scenarios (plain bucket, lock enabled, COMPLIANCE+days, GOVERNANCE+years, invalid mode, days+years conflict, mode without period, days without mode, zero days, non-numeric days, objectLockEnabled=false)
- [x] All existing tests pass unchanged
- [x] `go build ./...` compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bucket creation now supports Object Lock configuration (enable flag, retention mode and retention period) with enforced validation.

* **Bug Fixes / Validation**
  * Enforced rules to prevent conflicting or invalid Object Lock parameter combinations; invalid configs return errors.

* **Tests**
  * Added comprehensive tests covering valid and invalid Object Lock configurations and resulting bucket metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->