### PR TITLE
fix(ci): repair pre-commit checks for Go 1.24

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
+        exclude: ^(go\.mod|go\.sum)$
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.13.0
@@ -26,6 +27,6 @@ repos:
       - id: markdownlint-cli2
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.58.1
+    rev: v2.10.1
     hooks:
       - id: golangci-lint


### PR DESCRIPTION
## Summary

- Exclude `go.mod` and `go.sum` from codespell — it flags `unknwon` (a real GitHub username) as a typo
- Upgrade golangci-lint from v1.58.1 to v2.10.1 to support Go 1.24+

## Test plan

- [x] `pre-commit run --all-files` passes locally (all 13 hooks green)
- [ ] Verify CI passes on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated golangci-lint hook to the latest version for improved code quality checks.
  * Configured code spell-checking to exclude dependency files from validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->