### PR TITLE
fix(driver): improve error handling and concurrency safety

### DIFF
--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -52,6 +53,7 @@ type provisionerServer struct {
 	region           string
 	filerEndpoint    string
 	grpcDialOption   grpc.DialOption
+	mu               sync.Mutex // protects IAM read-modify-write
 }
 
 var _ cosispec.ProvisionerServer = (*provisionerServer)(nil)
@@ -191,6 +193,9 @@ func (s *provisionerServer) deleteBucket(ctx context.Context, id string) error {
 			IgnoreRecursiveError: true,
 		})
 		if err != nil {
+			if isNotFoundError(err) {
+				return nil // already gone — idempotent delete
+			}
 			return err
 		}
 		fc, err := readFilerConf(ctx, c)
@@ -253,7 +258,10 @@ func (s *provisionerServer) DriverGrantBucketAccess(ctx context.Context, req *co
 	accessKey, _ := GenerateAccessKeyID()
 	secretKey, _ := GenerateSecretAccessKey()
 
-	// read-modify-write IAM configuration
+	// atomic read-modify-write IAM configuration
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	var cfgBuf bytes.Buffer
 	if err := s.readS3Configuration(ctx, &cfgBuf); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -392,7 +400,7 @@ func (s *provisionerServer) readS3Configuration(ctx context.Context, buf *bytes.
 			Directory: filer.IamConfigDirectory,
 			Name:      filer.IamIdentityFile,
 		})
-		if err != nil && !strings.Contains(err.Error(), "no entry is found") {
+		if err != nil && !isNotFoundError(err) {
 			return err
 		}
 		if resp != nil && resp.Entry != nil && resp.Entry.Content != nil {
@@ -412,7 +420,7 @@ func (s *provisionerServer) saveS3Configuration(ctx context.Context, data []byte
 				IsDirectory: false,
 			},
 		})
-		if err == nil || !strings.Contains(err.Error(), "no entry is found") {
+		if err == nil || !isNotFoundError(err) {
 			return err
 		}
 		_, err = c.CreateEntry(ctx, &filer_pb.CreateEntryRequest{
@@ -432,6 +440,9 @@ func (s *provisionerServer) revokeBucketAccess(ctx context.Context, user string)
 }
 
 func (s *provisionerServer) configureS3Access(ctx context.Context, user, ak, sk string, actions []string, del bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	var buf bytes.Buffer
 	if err := s.readS3Configuration(ctx, &buf); err != nil {
 		return err
@@ -481,6 +492,16 @@ func (s *provisionerServer) configureS3Access(ctx context.Context, user, ak, sk 
 /* -------------------------------------------------------------------------- */
 /*                               utilities                                    */
 /* -------------------------------------------------------------------------- */
+
+// isNotFoundError checks whether err represents a "not found" condition.
+// It first checks for a proper gRPC NotFound status code, then falls back to
+// string matching for SeaweedFS filer which returns plain error strings.
+func isNotFoundError(err error) bool {
+	if status.Code(err) == codes.NotFound {
+		return true
+	}
+	return strings.Contains(err.Error(), "no entry is found")
+}
 
 // validateObjectLockParams checks BucketClass parameters related to Object Lock.
 func validateObjectLockParams(params map[string]string) error {

--- a/pkg/driver/provisioner_test.go
+++ b/pkg/driver/provisioner_test.go
@@ -20,10 +20,10 @@ package driver
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -66,7 +66,7 @@ func (f *fakeFiler) CreateEntry(_ context.Context, in *filer_pb.CreateEntryReque
 func (f *fakeFiler) UpdateEntry(_ context.Context, in *filer_pb.UpdateEntryRequest) (*filer_pb.UpdateEntryResponse, error) {
 	key := f.fileKey(in.Directory, in.Entry.Name)
 	if _, ok := f.files[key]; !ok {
-		return nil, fmt.Errorf("no entry is found in filer store")
+		return nil, status.Error(codes.NotFound, "no entry is found in filer store")
 	}
 	f.files[key] = in.Entry.Content
 	return &filer_pb.UpdateEntryResponse{}, nil
@@ -76,7 +76,7 @@ func (f *fakeFiler) LookupDirectoryEntry(_ context.Context, in *filer_pb.LookupD
 	key := f.fileKey(in.Directory, in.Name)
 	data, ok := f.files[key]
 	if !ok {
-		return nil, fmt.Errorf("no entry is found in filer store")
+		return nil, status.Error(codes.NotFound, "no entry is found in filer store")
 	}
 	return &filer_pb.LookupDirectoryEntryResponse{Entry: &filer_pb.Entry{
 		Content:    data,
@@ -85,8 +85,13 @@ func (f *fakeFiler) LookupDirectoryEntry(_ context.Context, in *filer_pb.LookupD
 }
 
 func (f *fakeFiler) DeleteEntry(_ context.Context, in *filer_pb.DeleteEntryRequest) (*filer_pb.DeleteEntryResponse, error) {
+	if in.Directory == "/buckets" && f.buckets != nil {
+		if _, ok := f.buckets[in.Name]; !ok {
+			return nil, status.Error(codes.NotFound, "no entry is found in filer store")
+		}
+		delete(f.buckets, in.Name)
+	}
 	delete(f.files, f.fileKey(in.Directory, in.Name))
-	delete(f.buckets, in.Name)
 	return &filer_pb.DeleteEntryResponse{}, nil
 }
 
@@ -753,4 +758,140 @@ func TestDriverCreateBucketObjectLock(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDriverDeleteBucketNotFound(t *testing.T) {
+	p, _ := newProv(t)
+
+	// deleting a non-existent bucket should succeed (idempotent)
+	resp, err := p.DriverDeleteBucket(context.Background(),
+		&cosispec.DriverDeleteBucketRequest{BucketId: "nonexistent"})
+	if err != nil {
+		t.Fatalf("expected no error for non-existent bucket, got %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+}
+
+func TestDriverDeleteBucketExisting(t *testing.T) {
+	p, ff := newProv(t)
+
+	// create a bucket first
+	_, err := p.DriverCreateBucket(context.Background(),
+		&cosispec.DriverCreateBucketRequest{Name: "to-delete"})
+	if err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if _, ok := ff.buckets["to-delete"]; !ok {
+		t.Fatal("bucket not found after creation")
+	}
+
+	// delete it
+	_, err = p.DriverDeleteBucket(context.Background(),
+		&cosispec.DriverDeleteBucketRequest{BucketId: "to-delete"})
+	if err != nil {
+		t.Fatalf("delete bucket: %v", err)
+	}
+	if _, ok := ff.buckets["to-delete"]; ok {
+		t.Error("bucket still exists after deletion")
+	}
+}
+
+func TestDriverGrantBucketAccessGRPCCodes(t *testing.T) {
+	p, _ := newProv(t)
+
+	cases := []struct {
+		name     string
+		req      *cosispec.DriverGrantBucketAccessRequest
+		wantCode codes.Code
+	}{
+		{
+			name:     "empty bucket",
+			req:      &cosispec.DriverGrantBucketAccessRequest{Name: "u"},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "empty user",
+			req:      &cosispec.DriverGrantBucketAccessRequest{BucketId: "b"},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "invalid policy",
+			req: &cosispec.DriverGrantBucketAccessRequest{
+				BucketId:   "b",
+				Name:       "u",
+				Parameters: map[string]string{"accessPolicy": "invalid"},
+			},
+			wantCode: codes.InvalidArgument,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := p.DriverGrantBucketAccess(context.Background(), c.req)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := status.Code(err); got != c.wantCode {
+				t.Errorf("code=%v want %v", got, c.wantCode)
+			}
+		})
+	}
+}
+
+func TestDriverRevokeBucketAccessGRPCCodes(t *testing.T) {
+	p, _ := newProv(t)
+
+	_, err := p.DriverRevokeBucketAccess(context.Background(),
+		&cosispec.DriverRevokeBucketAccessRequest{})
+	if err == nil {
+		t.Fatal("expected error for empty user")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("code=%v want %v", got, codes.InvalidArgument)
+	}
+}
+
+func TestConcurrentGrantAccess(t *testing.T) {
+	p, ff := newProv(t)
+	const n = 10
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			req := &cosispec.DriverGrantBucketAccessRequest{
+				BucketId: "b",
+				Name:     "user",
+			}
+			_, errs[idx] = p.DriverGrantBucketAccess(context.Background(), req)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
+
+	// verify IAM config has exactly n credentials for "user"
+	cfg := &iam_pb.S3ApiConfiguration{}
+	if data := ff.iam(); len(data) > 0 {
+		if err := filer.ParseS3ConfigurationFromBytes(data, cfg); err != nil {
+			t.Fatalf("parse IAM config: %v", err)
+		}
+	}
+	for _, id := range cfg.Identities {
+		if id.Name == "user" {
+			if len(id.Credentials) != n {
+				t.Errorf("credentials count=%d want %d", len(id.Credentials), n)
+			}
+			return
+		}
+	}
+	t.Fatal("identity 'user' not found in IAM config")
 }


### PR DESCRIPTION
# Describe your changes

Improve provisioner robustness with three targeted fixes:

- **gRPC status codes**: Replace fragile `strings.Contains(err, "no entry is found")` with proper `status.Code(err) == codes.NotFound` checks. Includes string fallback for SeaweedFS filer compatibility since it returns plain error strings rather than gRPC status errors.
- **Concurrency safety**: Add `sync.Mutex` to `provisionerServer` to protect IAM config read-modify-write operations from race conditions in concurrent grant/revoke requests.
- **Idempotent delete**: Make `deleteBucket` treat "not found" as success, so deleting an already-removed bucket doesn't return an error.

New tests:
- Delete non-existent bucket (idempotent)
- Delete existing bucket (verifies cleanup)
- gRPC status code assertions for grant/revoke errors
- Concurrent grant access with race detector (`-race`)

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket deletion is now idempotent and no longer errors for already-removed buckets
  * More reliable concurrent access-control operations, preventing race-related inconsistencies
  * Standardized detection and handling of not-found errors across S3 access management flows

* **Tests**
  * Added tests for bucket operations, access grants/revokes, error codes, and concurrent grant behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->