### PR TITLE
fix: remove stale COSI socket before binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work
 # Editor configurations
 .idea/
 .vscode/
+
+# locally-built driver binary (go build ./cmd/...)
+/seaweedfs-cosi-driver

--- a/cmd/seaweedfs-cosi-driver/main.go
+++ b/cmd/seaweedfs-cosi-driver/main.go
@@ -23,11 +23,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"io/ioutil"
+	"fmt"
 	"log"
+	"net"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs-cosi-driver/pkg/driver"
 	"github.com/seaweedfs/seaweedfs-cosi-driver/pkg/envflag"
@@ -65,6 +68,8 @@ func main() {
 	}
 }
 
+// run constructs the SeaweedFS COSI driver and serves the provisioner gRPC API
+// on the configured COSI endpoint until the context is cancelled.
 func run(ctx context.Context, opts runOptions) error {
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -84,11 +89,62 @@ func run(ctx context.Context, opts runOptions) error {
 		return err
 	}
 
+	// A non-graceful exit (SIGKILL/OOM/panic) leaves the COSI unix socket file
+	// behind — Go's net package only unlinks it on a graceful listener close.
+	// The socket lives on an emptyDir that survives container restarts, so the
+	// next bind fails with EADDRINUSE and wedges the pod in CrashLoopBackOff.
+	// Clear only a stale (dead) socket so the driver self-heals on restart.
+	if err := removeStaleSocket(opts.cosiEndpoint); err != nil {
+		return err
+	}
+
 	cosiSrv, err := provisioner.NewDefaultCOSIProvisionerServer(opts.cosiEndpoint, idSrv, provSrv)
 	if err != nil {
 		return err
 	}
 	return cosiSrv.Run(ctx)
+}
+
+// removeStaleSocket clears a leftover COSI unix socket so the gRPC server can
+// bind on restart. It parses the endpoint exactly like the provisioner sidecar
+// (net/url), so the path it removes is the path that will be bound. It removes
+// the path only if it exists, is a socket, and has no live listener — it never
+// deletes a regular file/directory or a socket that is still being served.
+func removeStaleSocket(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil
+	}
+	if u.Scheme != "unix" {
+		return nil
+	}
+	path := u.Path
+	if path == "" {
+		return nil
+	}
+
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat COSI socket %q: %w", path, err)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		// Not a socket (misconfigured endpoint) — never remove it.
+		return nil
+	}
+	if c, err := net.DialTimeout("unix", path, 200*time.Millisecond); err == nil {
+		// A live listener is still bound — leave it. The bind that follows will
+		// surface the real "address already in use" if another instance runs.
+		_ = c.Close()
+		return nil
+	}
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing stale COSI socket %q: %w", path, err)
+	}
+	return nil
 }
 
 func loadClientTLS() grpc.DialOption {
@@ -109,7 +165,7 @@ func loadClientTLS() grpc.DialOption {
 	// root CA
 	caCertPool := x509.NewCertPool()
 	if caFileName != "" {
-		caCert, err := ioutil.ReadFile(caFileName)
+		caCert, err := os.ReadFile(caFileName)
 		if err != nil {
 			log.Fatalf("failed to load CA: %v", err)
 		}

--- a/cmd/seaweedfs-cosi-driver/main_test.go
+++ b/cmd/seaweedfs-cosi-driver/main_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 SeaweedFS contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A stale socket (file present, no listener) must be removed so the next bind
+// succeeds — this is the CrashLoopBackOff self-heal.
+func TestRemoveStaleSocket_RemovesDeadSocket(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "cosi.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	// Keep the socket file on close so it looks like a non-graceful exit.
+	l.(*net.UnixListener).SetUnlinkOnClose(false)
+	if err := l.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := os.Stat(sock); err != nil {
+		t.Fatalf("setup: stale socket should exist: %v", err)
+	}
+
+	if err := removeStaleSocket("unix://" + sock); err != nil {
+		t.Fatalf("removeStaleSocket: %v", err)
+	}
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Fatalf("stale socket should be removed, stat err = %v", err)
+	}
+}
+
+// A socket with a live listener must NOT be removed — deleting it would orphan
+// an actively-served socket.
+func TestRemoveStaleSocket_KeepsLiveSocket(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "cosi.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	if err := removeStaleSocket("unix://" + sock); err != nil {
+		t.Fatalf("removeStaleSocket: %v", err)
+	}
+	if _, err := os.Stat(sock); err != nil {
+		t.Fatalf("live socket must not be removed: %v", err)
+	}
+}
+
+// No socket present is a no-op (clean first start).
+func TestRemoveStaleSocket_NoSocket(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "absent.sock")
+	if err := removeStaleSocket("unix://" + sock); err != nil {
+		t.Fatalf("removeStaleSocket: %v", err)
+	}
+}
+
+// A misconfigured endpoint pointing at a regular file must NOT delete that file.
+func TestRemoveStaleSocket_LeavesRegularFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "not-a-socket")
+	if err := os.WriteFile(f, []byte("keepme"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := removeStaleSocket("unix://" + f); err != nil {
+		t.Fatalf("removeStaleSocket: %v", err)
+	}
+	if _, err := os.Stat(f); err != nil {
+		t.Fatalf("regular file must not be removed: %v", err)
+	}
+}
+
+// Non-unix endpoints are ignored.
+func TestRemoveStaleSocket_NonUnixEndpoint(t *testing.T) {
+	if err := removeStaleSocket("tcp://127.0.0.1:9000"); err != nil {
+		t.Fatalf("removeStaleSocket: %v", err)
+	}
+}
+
+// A unix endpoint with no path is ignored without touching the filesystem.
+func TestRemoveStaleSocket_EmptyPath(t *testing.T) {
+	if err := removeStaleSocket("unix://"); err != nil {
+		t.Fatalf("removeStaleSocket: %v", err)
+	}
+}
+
+// The path removed is parsed the same way the provisioner sidecar binds it
+// (net/url), so the cleanup targets the exact path that will be bound.
+func TestRemoveStaleSocket_ParsesLikeURL(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sock := filepath.Join(sub, "cosi.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	l.(*net.UnixListener).SetUnlinkOnClose(false)
+	if err := l.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	endpoint := "unix://" + sock // absolute path -> three-slash form
+	if err := removeStaleSocket(endpoint); err != nil {
+		t.Fatalf("removeStaleSocket: %v", err)
+	}
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Fatalf("socket at url.Path should be removed, stat err = %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

The COSI gRPC socket (`unix:///var/lib/cosi/cosi.sock` by default) is created on an `emptyDir` shared between the driver and the COSI sidecar. Go's `net` package only unlinks a unix socket on a *graceful* listener close, so a non-graceful exit (SIGKILL / OOM / panic) leaves the socket file behind. The `emptyDir` survives container restarts, so the next start fails to bind:

```
listen unix /var/lib/cosi/cosi.sock: bind: address already in use
```

A single transient crash then wedges the pod in a permanent `CrashLoopBackOff`, recoverable only by deleting the pod, and object storage stays unusable in the meantime.

This fix comes from [Cozystack](https://cozystack.io), a CNCF Sandbox project that ships `seaweedfs-cosi-driver` as the COSI provisioner for its built-in S3 offering. It hits real users in production, so we are carrying the patch as a vendored fix in Cozystack and upstreaming it here so the whole driver community benefits. Tracked downstream in cozystack/cozystack#2429 (72 driver restarts observed on a single pod).

## Fix

Remove a stale socket before starting the provisioner server, so the driver self-heals on restart.

- The endpoint is parsed with `net/url` — the same way `provisioner.Run` derives the bind path (`url.Parse(addr).Path`) — so the path removed is exactly the path that will be bound, including for non-default endpoints.
- Removal is guarded: it deletes the path only if it exists, is a socket (`os.ModeSocket`), and has no live listener (a short `net.DialTimeout` probe). It never deletes a regular file/directory or a socket that is still being served.

## Tests

Adds `cmd/seaweedfs-cosi-driver/main_test.go` covering: stale socket removed, live socket kept, absent path no-op, regular file kept, non-unix endpoint ignored, and the `url.Path` parsing contract.

`go test`, `go vet`, `go build`, `gofmt`, and `golangci-lint` all pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service restart reliability by automatically cleaning up stale socket files, eliminating manual intervention requirements.

* **Tests**
  * Added comprehensive test coverage for socket cleanup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->